### PR TITLE
Refine layout of index and details views

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,7 +52,7 @@ function App() {
       <CssBaseline />
       <Header />
 
-      <Container maxWidth="lg" style={{ top: 67, position: "relative", paddingBottom: 16 }}>
+      <Container maxWidth="xl" style={{ padding: "16px" }}>
         <Switch>
           <Route exact path="/">
             <Redirect to="/filter" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,11 +21,16 @@ function App() {
         paper: themeDark ? "#021a40" : "#fff",
       },
       primary: {
-        main: "rgb(22, 150, 172)",
+        main: themeDark ? "#26cbe5" : "#0096ad",
         contrastText: "#FFF"
       },
       secondary: {
         main: "rgba(2, 130, 152)"
+      },
+      text: {
+        primary: themeDark ? "#FFFFFF" : "#353945",
+        secondary: themeDark ? "#d4d6e3" : "#596173",
+        hint: themeDark ? "#17305d" : "#8e97ab",
       }
     },
     typography: {
@@ -36,8 +41,53 @@ function App() {
     overrides: {
       MuiAppBar: {
         root: {
-          background: themeDark ? "#021a40" : "#FFF"
+          background: themeDark ? "#021a40" : "#FFF",
         }
+      },
+      MuiCheckbox: {
+        root: {
+          color: themeDark ? "#5a6887" : "#7a849c",
+          padding: '2px 8px',
+        },
+        colorSecondary: {
+          '&$checked': {
+            '&:hover': {
+              backgroundColor: 'transparent',
+            }
+          }
+        }
+      },
+      MuiIconButton: {
+        root: {
+          color: themeDark ? "#b5bccb" : "#7a849c",
+          '&:hover': {
+            backgroundColor: 'transparent',
+          },
+        },
+        colorPrimary: {
+          '&:hover': {
+            backgroundColor: 'transparent',
+          },
+        },
+        colorSecondary: {
+          '&:hover': {
+            backgroundColor: 'transparent',
+          },
+        },
+      },
+      MuiTouchRipple: {
+        rippleVisible: {
+          animation: 'none',
+          display: 'none',
+        },
+        childLeaving: {
+          animation: 'none',
+          display: 'none',
+        },
+        childPulsate: {
+          animation: 'none',
+          display: 'none',
+        },
       },
       MuiPaper: {
         root: {

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -3,6 +3,7 @@ import "./App.css";
 import { useHistory } from "react-router-dom";
 import QuestionsDisplay from "./components/QuestionsDisplay";
 import Filters from "./components/Filters";
+import Tags from "./components/Tags";
 import filterQuestions, { FilterType } from "./methods/filterQuestions";
 import { Zoom } from "@material-ui/core";
 import { useWindowSize } from "@reach/window-size";
@@ -53,12 +54,11 @@ const Main = () => {
         <div
           style={{
             display: windowSize.width > 750 ? "flex" : "block",
-            marginTop: "1.5em"
           }}
         >
           <Filters />
-
           <QuestionsDisplay questions={filteredQuestions} />
+          <Tags />
         </div>
       </Zoom>
     </>

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -53,7 +53,8 @@ const Main = () => {
       <Zoom in={managedQuestions.questions.length >= 1}>
         <div
           style={{
-            display: windowSize.width > 750 ? "flex" : "block",
+            display: "flex",
+            flexFlow: windowSize.width > 960 ? "row" : "column",
           }}
         >
           <Filters />

--- a/src/classes.ts
+++ b/src/classes.ts
@@ -8,9 +8,13 @@ export const useHeaderStyles = makeStyles((theme: Theme) =>
     },
     homeLink: {
       height: 35.38,
+      marginRight: theme.spacing(2),
+      [theme.breakpoints.down('sm')]: {
+        width: 35.38,
+        overflow: "hidden",
+      },
     },
     menuButton: {
-      marginRight: theme.spacing(2),
       color: theme.palette.text.primary,
       width: theme.spacing(20)
     },
@@ -23,6 +27,12 @@ export const useHeaderStyles = makeStyles((theme: Theme) =>
       lineHeight: 1,
       marginTop: theme.spacing(-0.25),
       textTransform: "uppercase",
+      [theme.breakpoints.down('sm')]: {
+        marginLeft: 0,
+      },
+      [theme.breakpoints.down('xs')]: {
+        display: "none"
+      },
     },
     titleDark: {
       color: "#26cbe5",
@@ -43,7 +53,11 @@ export const useHeaderStyles = makeStyles((theme: Theme) =>
         marginRight: theme.spacing(-1),
       },
       [theme.breakpoints.down('sm')]: {
-        minWidth: theme.spacing(35),
+        flex: 5,
+        minWidth: 0,
+      },
+      [theme.breakpoints.down('xs')]: {
+        marginRight: 0,
       },
       "& ::-webkit-search-cancel-button": {
         "-webkit-appearance": "none",

--- a/src/classes.ts
+++ b/src/classes.ts
@@ -16,12 +16,16 @@ export const useHeaderStyles = makeStyles((theme: Theme) =>
     },
     title: {
       marginLeft: theme.spacing(3.125),
-      color: "#6b758a",
-      flexGrow: 1,
+      color: "#007797",
+      flexGrow: 0.6,
       fontSize: 13,
+      letterSpacing: 1.6,
       lineHeight: 1,
       marginTop: theme.spacing(-0.25),
       textTransform: "uppercase",
+    },
+    titleDark: {
+      color: "#26cbe5",
     },
     search: {
       margin: "auto"
@@ -62,11 +66,11 @@ export const useQuestionDisplayStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       flex: 3.5,
-      height: 'calc(100vh - 99px)',
-      padding: theme.spacing(1),
+      maxHeight: "calc(100vh - 99px)",
+      padding: theme.spacing(1, 2, 2),
       margin: theme.spacing(0, 2),
       textDecoration: "none",
-      overflowY: 'auto',
+      overflowY: "auto",
       [theme.breakpoints.down('md')]: {
         flex: 2
       },
@@ -77,18 +81,39 @@ export const useQuestionDisplayStyles = makeStyles((theme: Theme) =>
       padding: theme.spacing(1),
       textDecoration: "none"
     },
+    headingBox: {
+      margin: theme.spacing(3, 1, 2),
+      "&:first-of-type": {
+        marginTop: theme.spacing(0.75),
+      }
+    },
     heading: {
       fontWeight: 900,
       color: theme.palette.primary.main,
     },
+    results: {
+      background: "#eff0f5",
+      borderRadius: theme.spacing(2),
+      color: theme.palette.text.secondary,
+      position: "sticky",
+      top: theme.spacing(1.5),
+      marginRight: theme.spacing(1),
+      padding: theme.spacing(0.25, 1.5),
+      float: "right",
+      zIndex: 2,
+    },
+    resultsDark: {
+      background: "#00062a",
+    },
     item: {
       flexGrow: 1,
+      fontSize: 15,
       padding: theme.spacing(1),
       textDecoration: "none",
       cursor: "pointer"
     },
     divider: {
-      margin: theme.spacing(0, -1),
+      margin: theme.spacing(0, -2),
     },
     chip: {
       marginRight: theme.spacing(0.5)
@@ -108,8 +133,8 @@ export const useFilterStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       flex: 1,
-      height: 'calc(100vh - 99px)',
-      overflowY: 'auto',
+      maxHeight: "calc(100vh - 99px)",
+      overflowY: "auto",
       padding: theme.spacing(1),
     },
     smallRoot: {
@@ -144,7 +169,7 @@ export const useFilterStyles = makeStyles((theme: Theme) =>
     },
     checkboxLabel: {
       lineHeight: 1.25,
-      marginTop: theme.spacing(1.375),
+      marginTop: theme.spacing(0.5),
     },
     section: {
       display: "flex",
@@ -155,7 +180,7 @@ export const useFilterStyles = makeStyles((theme: Theme) =>
     tag: {
       fontFamily: 'Lato',
       marginRight: theme.spacing(0.5),
-      marginTop: theme.spacing(0.5)
+      marginTop: theme.spacing(0.5),
     },
     button: {
       padding: theme.spacing(1)
@@ -168,22 +193,45 @@ export const useFilterStyles = makeStyles((theme: Theme) =>
   
   export const useQuestionStyles = makeStyles((theme: Theme) =>
   createStyles({
-    root: {
-      flexGrow: 1,
-      padding: theme.spacing(4)
+    container: {
+      display: "flex",
+      [theme.breakpoints.down('md')]: {
+        flexFlow: "column",
+      },
     },
-    description: {
-      background: "rgba(0,0,0, 0.05)",
-      borderRadius: theme.spacing(1)
+    root: {
+      borderRadius: theme.spacing(0.5, 0, 0, 0.5),
+      flex: 4,
+      overflowX: "auto",
+      padding: theme.spacing(4),
+      [theme.breakpoints.down('md')]: {
+        order: 2
+      },
     },
     title: {
       display: "flex",
-      "& > *": {
-        flexGrow: 1
-      },
     },
     titleText: {
-      width: "85%"
+      color: "#0096ad",
+      fontWeight: 900,
+      lineHeight: 1.25,
+      marginTop: theme.spacing(-0.5),
+    },
+    queryDescLayout: {
+      display: "flex",
+    },
+    description: {
+      marginBottom: theme.spacing(2),
+      [theme.breakpoints.down('md')]: {
+        fontSize: 18,
+      },
+    },
+    queries: {
+      flex: 4,
+      marginTop: theme.spacing(2.125),
+    },
+    queryGroup: {
+      display: "flex",
     },
     copy: {
       verticalAlign: "center",
@@ -191,19 +239,61 @@ export const useFilterStyles = makeStyles((theme: Theme) =>
       width: theme.spacing(6)
     },
     copyContainer: {
-      verticalAlign: "top"
+      marginTop: theme.spacing(0.375),
     },
     button: {
-      marginTop: theme.spacing(2),
       paddingLeft: theme.spacing(0.75),
+      position: "absolute",
+      left: 24,
+      [theme.breakpoints.down('md')]: {
+        position: "static",
+        marginBottom: theme.spacing(2),
+      },
     },
     queryBox: {
-      paddingLeft: theme.spacing(1)
+      paddingLeft: theme.spacing(1),
+    },
+    sidebar: {
+      borderRadius: theme.spacing(0, 0.5, 0.5, 0),
+      flex: 1,
+      padding: theme.spacing(4),
+      position: "relative",
+      '&:before': {
+        background: "rgba(227, 229, 239, 0.2)",
+        display: "block",
+        content: `""`,
+        height: "100%",
+        position: "absolute",
+        width: "100%",
+        left: 0,
+        top: 0,
+      }
+    },
+    sidebarDark: {
+      '&:before': {
+        background: "rgba(0, 6, 42, 0.2)",
+      }
+    },
+    integrationGroup: {
+      alignItems: 'center',
+      display: 'flex',
+      marginBottom: theme.spacing(2.5),
+    },
+    integrationIcon: {
+      marginRight: theme.spacing(1.5),
+      height: 48,
+      width: 48,
+    },
+    integrationTitle: {
+      color: theme.palette.text.secondary,
+      fontSize: 18,
+      fontWeight: 900,
     },
     tag: {
       fontFamily: 'Lato',
-      marginLeft: theme.spacing(0.5)
-    }
+      marginRight: theme.spacing(0.5),
+      marginTop: theme.spacing(0.5),
+    },
   })
   );
   

--- a/src/classes.ts
+++ b/src/classes.ts
@@ -103,8 +103,9 @@ export const useQuestionDisplayStyles = makeStyles((theme: Theme) =>
       margin: theme.spacing(0, 2),
       textDecoration: "none",
       overflowY: "auto",
-      [theme.breakpoints.down('md')]: {
-        flex: 2
+      [theme.breakpoints.down('sm')]: {
+        flex: 2,
+        maxHeight: "none",
       },
     },
     smallRoot: {
@@ -215,21 +216,26 @@ export const useQuestionDisplayStyles = makeStyles((theme: Theme) =>
     },
     section: {
       display: "flex",
-      [theme.breakpoints.down('sm')]: {
+      [theme.breakpoints.down('md')]: {
         flexFlow: "wrap",
       },
-      [theme.breakpoints.down('xs')]: {
+      [theme.breakpoints.down('sm')]: {
         flexFlow: "nowrap",
       },
     },
     tagsPaper: {
       [theme.breakpoints.down('sm')]: {
         borderRadius: 0,
+        borderBottom: `solid 1px ${theme.palette.divider}`, 
+        borderTop: `solid 1px ${theme.palette.divider}`, 
         order: 2,
       },
     },
     tags: {
-      margin: theme.spacing(1.25, 1, 2),
+      margin: theme.spacing(1.625, 1, 2),
+      [theme.breakpoints.down('md')]: {
+        marginTop: 0,
+      },
     },
     tag: {
       fontFamily: 'Lato',
@@ -240,16 +246,16 @@ export const useQuestionDisplayStyles = makeStyles((theme: Theme) =>
       padding: theme.spacing(1)
     },
     buttonGroup: {
-      [theme.breakpoints.down('sm')]: {
+      [theme.breakpoints.down('md')]: {
         margin: theme.spacing(2, 0, 1),
         width: "100%",
       },
-      [theme.breakpoints.down('xs')]: {
+      [theme.breakpoints.down('sm')]: {
         margin: 0,
         width: "35%",
       },
       "& button": {
-        [theme.breakpoints.down('sm')]: {
+        [theme.breakpoints.down('md')]: {
           flex: 1,
         },
       }
@@ -331,6 +337,7 @@ export const useQuestionDisplayStyles = makeStyles((theme: Theme) =>
       position: "relative",
       [theme.breakpoints.down('md')]: {
         borderRadius: theme.spacing(0.5, 0.5, 0, 0),
+        borderBottom: "solid 1px #d4d6e3",
       },
       '&:before': {
         background: "rgba(227, 229, 239, 0.2)",

--- a/src/classes.ts
+++ b/src/classes.ts
@@ -113,6 +113,13 @@ export const useQuestionDisplayStyles = makeStyles((theme: Theme) =>
       padding: theme.spacing(1),
       textDecoration: "none"
     },
+    questionsCard: {
+      [theme.breakpoints.down('sm')]: {
+        borderRadius: theme.spacing(0, 0, 0.5, 0.5),
+        margin: 0,
+        order: 3,
+      },
+    },
     headingBox: {
       margin: theme.spacing(3, 1, 2),
       "&:first-of-type": {
@@ -159,9 +166,9 @@ export const useQuestionDisplayStyles = makeStyles((theme: Theme) =>
       marginTop: theme.spacing(-0.5),
     }
   })
-);
-
-export const useFilterStyles = makeStyles((theme: Theme) =>
+  );
+  
+  export const useFilterStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       flex: 1,
@@ -177,7 +184,10 @@ export const useFilterStyles = makeStyles((theme: Theme) =>
     },
     filterSection: {
       borderRadiusBottomLeft: theme.spacing(1),
-      borderRadiusBottomRight: theme.spacing(1)
+      borderRadiusBottomRight: theme.spacing(1),
+      [theme.breakpoints.down('sm')]: {
+        borderRadius: theme.spacing(),
+      },
     },
     divider: {
       margin: theme.spacing(0, -1, 2),
@@ -205,6 +215,18 @@ export const useFilterStyles = makeStyles((theme: Theme) =>
     },
     section: {
       display: "flex",
+      [theme.breakpoints.down('sm')]: {
+        flexFlow: "wrap",
+      },
+      [theme.breakpoints.down('xs')]: {
+        flexFlow: "nowrap",
+      },
+    },
+    tagsPaper: {
+      [theme.breakpoints.down('sm')]: {
+        borderRadius: 0,
+        order: 2,
+      },
     },
     tags: {
       margin: theme.spacing(1.25, 1, 2),
@@ -216,6 +238,21 @@ export const useFilterStyles = makeStyles((theme: Theme) =>
     },
     button: {
       padding: theme.spacing(1)
+    },
+    buttonGroup: {
+      [theme.breakpoints.down('sm')]: {
+        margin: theme.spacing(2, 0, 1),
+        width: "100%",
+      },
+      [theme.breakpoints.down('xs')]: {
+        margin: 0,
+        width: "35%",
+      },
+      "& button": {
+        [theme.breakpoints.down('sm')]: {
+          flex: 1,
+        },
+      }
     },
     linkText: {
       color: "#BBC"
@@ -229,6 +266,7 @@ export const useFilterStyles = makeStyles((theme: Theme) =>
       display: "flex",
       [theme.breakpoints.down('md')]: {
         flexFlow: "column",
+        order: 3,
       },
     },
     root: {
@@ -237,7 +275,8 @@ export const useFilterStyles = makeStyles((theme: Theme) =>
       overflowX: "auto",
       padding: theme.spacing(4),
       [theme.breakpoints.down('md')]: {
-        order: 2
+        order: 2,
+        borderRadius: theme.spacing(0, 0, 0.5, 0.5),
       },
     },
     title: {
@@ -290,6 +329,9 @@ export const useFilterStyles = makeStyles((theme: Theme) =>
       flex: 1,
       padding: theme.spacing(4),
       position: "relative",
+      [theme.breakpoints.down('md')]: {
+        borderRadius: theme.spacing(0.5, 0.5, 0, 0),
+      },
       '&:before': {
         background: "rgba(227, 229, 239, 0.2)",
         display: "block",

--- a/src/classes.ts
+++ b/src/classes.ts
@@ -293,15 +293,25 @@ export const useQuestionDisplayStyles = makeStyles((theme: Theme) =>
       fontWeight: 900,
       lineHeight: 1.25,
       marginTop: theme.spacing(-0.5),
+      width: "92.5%",
+      [theme.breakpoints.down('sm')]: {
+        width: "100%",
+      },
     },
     queryDescLayout: {
       display: "flex",
     },
     description: {
-      marginBottom: theme.spacing(2),
-      [theme.breakpoints.down('md')]: {
-        fontSize: 18,
+      color: theme.palette.text.secondary,
+      fontSize: 18,
+      marginBottom: theme.spacing(2.5),
+      width: "92.5%",
+      [theme.breakpoints.down('sm')]: {
+        width: "100%",
       },
+    },
+    descriptionDark: {
+      color: "#8690a8",
     },
     queries: {
       flex: 4,
@@ -336,8 +346,14 @@ export const useQuestionDisplayStyles = makeStyles((theme: Theme) =>
       padding: theme.spacing(4),
       position: "relative",
       [theme.breakpoints.down('md')]: {
+        alignItems: "center",
         borderRadius: theme.spacing(0.5, 0.5, 0, 0),
         borderBottom: "solid 1px #d4d6e3",
+        display: "flex",
+        flexFlow: "wrap",
+        paddingBottom: theme.spacing(3),
+        paddingTop: theme.spacing(3),
+        justifyContent: "space-between",
       },
       '&:before': {
         background: "rgba(227, 229, 239, 0.2)",
@@ -351,6 +367,9 @@ export const useQuestionDisplayStyles = makeStyles((theme: Theme) =>
       }
     },
     sidebarDark: {
+      [theme.breakpoints.down('md')]: {
+        borderBottom: "solid 1px #00062a",
+      },
       '&:before': {
         background: "rgba(0, 6, 42, 0.2)",
       }
@@ -358,7 +377,14 @@ export const useQuestionDisplayStyles = makeStyles((theme: Theme) =>
     integrationGroup: {
       alignItems: 'center',
       display: 'flex',
-      marginBottom: theme.spacing(2.5),
+      margin: theme.spacing(0, 2, 2, 0),
+      [theme.breakpoints.down('md')]: {
+        marginBottom: 0,
+      },
+      [theme.breakpoints.down('sm')]: {
+        marginBottom: theme.spacing(1.5),
+        flex: "100%",
+      },
     },
     integrationIcon: {
       marginRight: theme.spacing(1.5),
@@ -369,6 +395,15 @@ export const useQuestionDisplayStyles = makeStyles((theme: Theme) =>
       color: theme.palette.text.secondary,
       fontSize: 18,
       fontWeight: 900,
+    },
+    tags: {
+      [theme.breakpoints.down('md')]: {
+        margin: theme.spacing(-0.5, 0, 0, 0),
+        textAlign: "right",
+      },
+      [theme.breakpoints.down('sm')]: {
+        textAlign: "left",
+      },
     },
     tag: {
       fontFamily: 'Lato',

--- a/src/classes.ts
+++ b/src/classes.ts
@@ -12,9 +12,6 @@ export const useHeaderStyles = makeStyles((theme: Theme) =>
     menuButton: {
       marginRight: theme.spacing(2),
       color: theme.palette.text.primary,
-      verticalAlign: "center",
-      position: "relative",
-      top: "1.5px",
       width: theme.spacing(20)
     },
     title: {
@@ -23,6 +20,7 @@ export const useHeaderStyles = makeStyles((theme: Theme) =>
       flexGrow: 1,
       fontSize: 13,
       lineHeight: 1,
+      marginTop: theme.spacing(-0.25),
       textTransform: "uppercase",
     },
     search: {
@@ -63,18 +61,20 @@ export const useHeaderStyles = makeStyles((theme: Theme) =>
 export const useQuestionDisplayStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
-      flexGrow: 1,
-      width: "60%",
+      flex: 3.5,
+      height: 'calc(100vh - 99px)',
       padding: theme.spacing(1),
-      marginLeft: "1%",
+      margin: theme.spacing(0, 2),
       textDecoration: "none",
+      overflowY: 'auto',
+      [theme.breakpoints.down('md')]: {
+        flex: 2
+      },
     },
     smallRoot: {
       display: "block",
       width: "100%",
       padding: theme.spacing(1),
-      marginTop: "1%",
-      marginBottom: "1%",
       textDecoration: "none"
     },
     heading: {
@@ -107,15 +107,15 @@ export const useQuestionDisplayStyles = makeStyles((theme: Theme) =>
 export const useFilterStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
-      flexGrow: 1,
-      width: "16%",
-      padding: theme.spacing(1)
+      flex: 1,
+      height: 'calc(100vh - 99px)',
+      overflowY: 'auto',
+      padding: theme.spacing(1),
     },
     smallRoot: {
       display: "block",
       width: "100%",
       padding: theme.spacing(1),
-      marginTop: "1%",
       textDecoration: "none"
     },
     filterSection: {
@@ -127,6 +127,7 @@ export const useFilterStyles = makeStyles((theme: Theme) =>
     },
     subtitle: {
       color: "#8e97ab",
+      flex: 1,
       fontSize: 12,
       fontWeight: 700,
       marginTop: theme.spacing(0.625),
@@ -148,6 +149,9 @@ export const useFilterStyles = makeStyles((theme: Theme) =>
     section: {
       display: "flex",
     },
+    tags: {
+      margin: theme.spacing(1.25, 1, 2),
+    },
     tag: {
       fontFamily: 'Lato',
       marginRight: theme.spacing(0.5),
@@ -166,11 +170,9 @@ export const useFilterStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       flexGrow: 1,
-      marginTop: "1%",
       padding: theme.spacing(4)
     },
     description: {
-      padding: "1%",
       background: "rgba(0,0,0, 0.05)",
       borderRadius: theme.spacing(1)
     },
@@ -179,7 +181,6 @@ export const useFilterStyles = makeStyles((theme: Theme) =>
       "& > *": {
         flexGrow: 1
       },
-      marginBottom: "0.5%"
     },
     titleText: {
       width: "85%"

--- a/src/classes.ts
+++ b/src/classes.ts
@@ -31,13 +31,31 @@ export const useHeaderStyles = makeStyles((theme: Theme) =>
       margin: "auto"
     },
     input: {
-      position: "relative",
+      background: "#eff0f5",
+      borderRadius: theme.spacing(0.5),
       color: theme.palette.text.primary,
+      height: 40,
       minWidth: theme.spacing(45),
+      padding: "10.5px 8px 10.5px 14px",
+      position: "relative",
+      [theme.breakpoints.down('md')]: {
+        marginLeft: "auto",
+        marginRight: theme.spacing(-1),
+      },
+      [theme.breakpoints.down('sm')]: {
+        minWidth: theme.spacing(35),
+      },
+      "& ::-webkit-search-cancel-button": {
+        "-webkit-appearance": "none",
+        cursor: "pointer",
+        height: 20,
+        width: 20,
+        backgroundImage: `url("data:image/svg+xml,%3Csvg id='Layer_1' data-name='Layer 1' xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'%3E%3Cg%3E%3Cline x1='15' y1='5' x2='5' y2='15' fill='none' stroke='%237a849c' stroke-linecap='round' stroke-linejoin='round' stroke-width='2'/%3E%3Cline x1='5' y1='5' x2='15' y2='15' fill='none' stroke='%237a849c' stroke-linecap='round' stroke-linejoin='round' stroke-width='2'/%3E%3C/g%3E%3C/svg%3E%0A")`,
+      },
     },
-    inputSelected: {
-      borderColor:
-        "linear-gradient(0.6turn, rgb(234, 254, 65), rgb(22, 150, 172))"
+    inputDark: {
+      background: "#00062a",
+      color: "#e2e4ea",
     },
     icon: {
       marginRight: theme.spacing(1)

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -3,20 +3,13 @@ import {
   Paper,
   Icon,
   Box,
-  Chip,
   Typography,
-  Avatar,
-  Button,
-  ButtonGroup,
   Hidden,
   Checkbox,
-  Zoom,
   FormControlLabel,
   Divider
 } from "@material-ui/core";
 import { useFilterStyles } from "../classes";
-import DoneIcon from "@material-ui/icons/Done";
-import TagIcon from "react-feather/dist/icons/tag";
 import IntegrationIcon from "react-feather/dist/icons/zap";
 import CategoryIcon from "react-feather/dist/icons/grid";
 import { useWindowSize } from "@reach/window-size";
@@ -28,12 +21,7 @@ const Filters = () => {
     categories,
     managedQuestions,
     integrations,
-    tagFilter,
-    allTags,
-    tags,
-    setFilterLogic,
     setCategory,
-    setTag,
     setIntegration
   } = useContext(Context);
 
@@ -100,54 +88,6 @@ const Filters = () => {
                   />
                   )
                   )}
-        </Box>
-        <Divider className={classes.divider} />
-        <Box m={1} className={classes.section}>
-          <Icon classes={{ root: classes.icon}}>
-            <TagIcon />
-          </Icon>
-          <Typography variant="h6" className={classes.subtitle}>Tags</Typography>
-        </Box>
-        <Box m={2}>
-          <ButtonGroup>
-            <Button
-              color={tagFilter === "all" ? "primary" : "default"}
-              onClick={() => setFilterLogic("all")}
-            >
-              Filter by all
-            </Button>
-            <Button
-              color={tagFilter === "any" ? "primary" : "default"}
-              onClick={() => setFilterLogic("any")}
-            >
-              Filter by any
-            </Button>
-          </ButtonGroup>
-        </Box>
-        <Box m={2} className={classes.section}>
-          <Box>
-            {allTags.sort().map((tag: string, index: number) => (
-              <Chip
-                color="primary"
-                variant="outlined"
-                avatar={
-                  tags.includes(tag) ? (
-                    <Zoom in={tags.includes(tag)}>
-                      <Avatar>
-                        <DoneIcon />
-                      </Avatar>
-                    </Zoom>
-                  ) : (
-                    undefined
-                  )
-                }
-                className={classes.tag}
-                key={index}
-                onClick={() => setTag(tag)}
-                label={tag}
-              />
-            ))}
-          </Box>
         </Box>
       </Paper>
     </Hidden>

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -79,15 +79,15 @@ const Filters = () => {
               }
               label={
                 <>
-                      {Object.keys(managedQuestions.integrations).length > 0 &&
-                      integration !== "none"
-                      ? managedQuestions.integrations[integration].title
-                      : "None"}
-                    </>
-                  }
-                  />
-                  )
-                  )}
+                  {Object.keys(managedQuestions.integrations).length > 0 &&
+                  integration !== "none"
+                  ? managedQuestions.integrations[integration].title
+                  : "None"}
+                </>
+              }
+            />
+          )
+        )}
         </Box>
       </Paper>
     </Hidden>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -41,7 +41,7 @@ const Header = () => {
     <div>
       <AppBar
         className={classes.root}
-        position="fixed"
+        position="static"
         elevation={0}
         color="inherit"
       >

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,7 +5,7 @@ import Toolbar from "@material-ui/core/Toolbar";
 import Typography from "@material-ui/core/Typography";
 import JupiterOneLogo from "./jupiterone-logo.svg";
 import JupiterOneLogoDark from "./jupiterone-logo-reversed.svg";
-import TextField from "@material-ui/core/TextField";
+import InputBase from "@material-ui/core/InputBase";
 import IconButton from "@material-ui/core/IconButton";
 import Snackbar from "@material-ui/core/Snackbar";
 import Tooltip from "@material-ui/core/Tooltip";
@@ -53,24 +53,20 @@ const Header = () => {
           <Typography className={clsx(classes.title, themeDark ? classes.titleDark : undefined)}>
             Questions Library
           </Typography>
-          <div className={windowSize.width < 500 ? classes.headerPart : ""}>
-            {!history.location.pathname.includes("/question") && (
-              <TextField
-                type="search"
-                variant="outlined"
-                className={classes.input}
-                size="small"
-                placeholder={"Search"}
-                value={searchText}
-                onChange={(e: any) => {
-                  setSearchText(e.target.value);
-                  setSearch(e.target.value);
-                }}
-              />
-            )}
-          </div>
+          {!history.location.pathname.includes("/question") && (
+            <InputBase
+              type="search"
+              className={clsx(classes.input, themeDark ? classes.inputDark : undefined)}
+              placeholder={"Search"}
+              value={searchText}
+              onChange={(e: any) => {
+                setSearchText(e.target.value);
+                setSearch(e.target.value);
+              }}
+            />
+          )}
           <Hidden smDown>
-            <div className={`${classes.headerPart} ${classes.alignRight}`}>
+            <div className={clsx(classes.headerPart, classes.alignRight)}>
               <Tooltip title="Launch JupiterOne">
                 <IconButton href="https://apps.us.jupiterone.io">
                   <LaunchIcon />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useContext } from "react";
+import clsx from "clsx";
 import AppBar from "@material-ui/core/AppBar";
 import Toolbar from "@material-ui/core/Toolbar";
 import Typography from "@material-ui/core/Typography";
@@ -49,7 +50,7 @@ const Header = () => {
           <Link className={classes.homeLink} to="/">
             <img className={classes.menuButton} src={themeDark ? JupiterOneLogoDark : JupiterOneLogo } />
           </Link>
-          <Typography className={classes.title}>
+          <Typography className={clsx(classes.title, themeDark ? classes.titleDark : undefined)}>
             Questions Library
           </Typography>
           <div className={windowSize.width < 500 ? classes.headerPart : ""}>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -68,7 +68,7 @@ const Header = () => {
           <Hidden smDown>
             <div className={clsx(classes.headerPart, classes.alignRight)}>
               <Tooltip title="Launch JupiterOne">
-                <IconButton href="https://apps.us.jupiterone.io">
+                <IconButton href="https://apps.us.jupiterone.io" target="_blank">
                   <LaunchIcon />
                 </IconButton>
               </Tooltip>

--- a/src/components/QuestionDisplay.tsx
+++ b/src/components/QuestionDisplay.tsx
@@ -8,7 +8,10 @@ import {
   IconButton,
   Snackbar,
   Tooltip,
+  Container,
+  Divider,
 } from "@material-ui/core";
+import clsx from "clsx";
 import { Alert } from "@material-ui/lab";
 import { useParams, useHistory } from "react-router";
 import { useQuestionStyles } from "../classes";
@@ -20,6 +23,7 @@ import ChevronLeftIcon from "react-feather/dist/icons/chevron-left";
 import Context from "../AppContext";
 
 const QuestionDisplay = () => {
+  const { themeDark } = React.useContext(Context);
   const { managedQuestions } = useContext(Context);
   const [copied, setCopied] = useState(false);
   const params: { questionTitle?: string } = useParams();
@@ -41,51 +45,81 @@ const QuestionDisplay = () => {
 
   return (
     <>
-      <Button
-        color="secondary"
-        className={classes.button}
-        variant="contained"
-        onClick={() => {
-          history.goBack();
-        }}
-      >
-        {" "}
-        <ChevronLeftIcon /> Back
-      </Button>
-      <Paper elevation={0} className={classes.root}>
+      <Container>
+        <Button
+          color="primary"
+          className={classes.button}
+          size="small"
+          variant="outlined"
+          onClick={() => {
+            history.goBack();
+          }}
+        >
+          <ChevronLeftIcon /> Back
+        </Button>
         {question ? (
-          <div>
-            <Box>
+          <div className={classes.container}>
+            <Paper elevation={0} className={classes.root}>
+              <Box className={classes.title}>
+                <Typography variant="h6" className={classes.titleText}>
+                  {question.title}
+                </Typography>
+              </Box>
+              <div className={classes.queryDescLayout}>
+                <Box className={classes.queries}>
+                  <Divider />
+                  {(question.queries || []).map((query: any) => (
+                    <>
+                      <Box className={classes.queryGroup} key={query.query}>
+                        <div className={classes.copyContainer}>
+                          <Tooltip title="Copy query">
+                            <IconButton
+                              color="primary"
+                              className={classes.copy}
+                              onClick={() => {
+                                copy(query.query);
+                                setCopied(true);
+                              }}
+                              children={<CopyIcon />}
+                              />
+                          </Tooltip>
+                        </div>
+                        <code className={classes.queryBox}>
+                          <pre>{query.query}</pre>
+                        </code>
+                      </Box>
+                      <Divider />
+                    </>
+                  ))}
+                </Box>
+              </div>
+            </Paper>
+            <Paper elevation={0} className={clsx(classes.sidebar, themeDark ? classes.sidebarDark : undefined)}>
               {question.integration ? (
-                <div>
+                <div className={classes.integrationGroup}>
                   <img
-                    style={{ margin: "auto", width: "2em" }}
+                    className={classes.integrationIcon}
                     src={`https://raw.githubusercontent.com/JupiterOne/docs/master/assets/icons/${
                       managedQuestions.integrations[question.integration].type
                     }.svg`}
                   />
                   <Typography
-                    style={{ position: "relative", top: "-7px" }}
+                    className={classes.integrationTitle}
                     variant="subtitle1"
                     component="span"
                   >
-                    {" "}
                     {managedQuestions.integrations[question.integration].title}
                   </Typography>
                 </div>
               ) : null}
-            </Box>
-            <Box className={classes.title}>
-              <Typography variant="h6" className={classes.titleText}>
-                {question.title}
-              </Typography>
+              <Box className={classes.description}>{question.description}</Box>
               {question.tags === undefined ||
                 question.tags.map((tag: string) => (
                   <Chip
                     key={tag}
                     className={classes.tag}
                     variant="outlined"
-                    color="secondary"
+                    color="primary"
                     onClick={() => {
                       window.location.replace(
                         `/filter?tags=${tag}&tagFilter=all`
@@ -94,32 +128,7 @@ const QuestionDisplay = () => {
                     label={tag}
                   />
                 ))}
-            </Box>
-            <Box className={classes.description}>{question.description}</Box>
-            <br />
-            <Typography>Queries</Typography>
-            <Box>
-              {(question.queries || []).map((query: any) => (
-                <Box key={query.query} style={{ display: "flex" }} mt={2} m={0}>
-                  <div className={classes.copyContainer}>
-                    <Tooltip title="Copy query">
-                      <IconButton
-                        color="primary"
-                        className={classes.copy}
-                        onClick={() => {
-                          copy(query.query);
-                          setCopied(true);
-                        }}
-                        children={<CopyIcon />}
-                        />
-                    </Tooltip>
-                  </div>
-                  <code className={classes.queryBox}>
-                    <pre>{query.query}</pre>
-                  </code>
-                </Box>
-              ))}
-            </Box>
+            </Paper>
             <Snackbar
               open={copied}
               autoHideDuration={3000}
@@ -129,9 +138,9 @@ const QuestionDisplay = () => {
             </Snackbar>
           </div>
         ) : (
-          <div>Nothing to display.</div>
+          <Paper elevation={0} className={classes.root}>Nothing to display.</Paper>
         )}
-      </Paper>
+      </Container>
     </>
   );
 };

--- a/src/components/QuestionDisplay.tsx
+++ b/src/components/QuestionDisplay.tsx
@@ -61,12 +61,13 @@ const QuestionDisplay = () => {
           <div className={classes.container}>
             <Paper elevation={0} className={classes.root}>
               <Box className={classes.title}>
-                <Typography variant="h6" className={classes.titleText}>
+                <Typography variant="h5" className={classes.titleText}>
                   {question.title}
                 </Typography>
               </Box>
               <div className={classes.queryDescLayout}>
                 <Box className={classes.queries}>
+                  <Box  className={clsx(classes.description, themeDark ? classes.descriptionDark : undefined)}>{question.description}</Box>
                   <Divider />
                   {(question.queries || []).map((query: any) => (
                     <>
@@ -112,22 +113,23 @@ const QuestionDisplay = () => {
                   </Typography>
                 </div>
               ) : null}
-              <Box className={classes.description}>{question.description}</Box>
-              {question.tags === undefined ||
-                question.tags.map((tag: string) => (
-                  <Chip
-                    key={tag}
-                    className={classes.tag}
-                    variant="outlined"
-                    color="primary"
-                    onClick={() => {
-                      window.location.replace(
-                        `/filter?tags=${tag}&tagFilter=all`
-                      );
-                    }}
-                    label={tag}
-                  />
+              <div className={classes.tags}>
+                {question.tags === undefined ||
+                  question.tags.map((tag: string) => (
+                    <Chip
+                      key={tag}
+                      className={classes.tag}
+                      variant="outlined"
+                      color="primary"
+                      onClick={() => {
+                        window.location.replace(
+                          `/filter?tags=${tag}&tagFilter=all`
+                          );
+                        }}
+                        label={tag}
+                    />
                 ))}
+              </div>
             </Paper>
             <Snackbar
               open={copied}

--- a/src/components/QuestionsDisplay.tsx
+++ b/src/components/QuestionsDisplay.tsx
@@ -26,7 +26,7 @@ const QuestionsDisplay = (props: Props) => {
   return (
     <Card
       elevation={0}
-      className={windowSize.width > 750 ? classes.root : classes.smallRoot}
+      className={clsx(classes.questionsCard, windowSize.width > 750 ? classes.root : classes.smallRoot)}
     >
       <Box className={clsx(classes.results, themeDark ? classes.resultsDark : undefined)}>
         {props.questions.length} of {managedQuestions.questions.length}

--- a/src/components/QuestionsDisplay.tsx
+++ b/src/components/QuestionsDisplay.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from "react";
+import clsx from "clsx";
 import { Typography, Card, Icon, Box, Divider } from "@material-ui/core";
 import { Question } from "../types";
 import { useQuestionDisplayStyles } from "../classes";
@@ -14,6 +15,7 @@ interface Props {
 }
 
 const QuestionsDisplay = (props: Props) => {
+  const { themeDark } = React.useContext(Context);
   const { managedQuestions } = useContext(Context);
   const classes = useQuestionDisplayStyles();
   const history = useHistory();
@@ -26,18 +28,16 @@ const QuestionsDisplay = (props: Props) => {
       elevation={0}
       className={windowSize.width > 750 ? classes.root : classes.smallRoot}
     >
-      <Box style={{ textAlign: "right" }} mr={1} mb={-3}>
-        <em>
-          {props.questions.length} of {managedQuestions.questions.length}
-        </em>
+      <Box className={clsx(classes.results, themeDark ? classes.resultsDark : undefined)}>
+        {props.questions.length} of {managedQuestions.questions.length}
       </Box>
       {Object.keys(grouped).map((category, index) => (
-        <div>
-          <Box m={1} mt={2}>
+        <>
+          <p className={classes.headingBox}>
             <Typography variant="h5" className={classes.heading}>
               {category === "undefined" ? "No Category" : category}
             </Typography>
-          </Box>
+          </p>
           <Divider className={classes.divider}/>
           {grouped[category].map(question => (
             <>
@@ -54,7 +54,7 @@ const QuestionsDisplay = (props: Props) => {
               <Divider className={classes.divider}/>
             </>
           ))}
-        </div>
+        </>
       ))}
     </Card>
   );

--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -35,14 +35,14 @@ const Tags = () => {
     <Hidden>
       <Paper
         elevation={0}
-        className={windowSize.width > 750 ? classes.root : classes.smallRoot}
+        className={clsx(classes.tagsPaper, windowSize.width > 750 ? classes.root : classes.smallRoot)}
       >
         <Box m={1} className={classes.section}>
           <Icon classes={{ root: classes.icon}}>
             <TagIcon />
           </Icon>
           <Typography variant="h6" className={classes.subtitle}>Tags</Typography>
-          <ButtonGroup>
+          <ButtonGroup className={classes.buttonGroup}>
             <Tooltip title="Filter by All">
               <Button
                 size="small"

--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -1,0 +1,96 @@
+import React, { useContext } from "react";
+import {
+  Paper,
+  Icon,
+  Box,
+  Chip,
+  Typography,
+  Avatar,
+  Button,
+  ButtonGroup,
+  Hidden,
+  Zoom,
+  Tooltip,
+} from "@material-ui/core";
+import clsx from "clsx";
+import { useFilterStyles } from "../classes";
+import DoneIcon from "@material-ui/icons/Done";
+import TagIcon from "react-feather/dist/icons/tag";
+import { useWindowSize } from "@reach/window-size";
+import Context from "../AppContext";
+
+const Tags = () => {
+  const {
+    tagFilter,
+    allTags,
+    tags,
+    setFilterLogic,
+    setTag,
+  } = useContext(Context);
+
+  const classes = useFilterStyles();
+  const windowSize = useWindowSize();
+
+  return (
+    <Hidden>
+      <Paper
+        elevation={0}
+        className={windowSize.width > 750 ? classes.root : classes.smallRoot}
+      >
+        <Box m={1} className={classes.section}>
+          <Icon classes={{ root: classes.icon}}>
+            <TagIcon />
+          </Icon>
+          <Typography variant="h6" className={classes.subtitle}>Tags</Typography>
+          <ButtonGroup>
+            <Tooltip title="Filter by All">
+              <Button
+                size="small"
+                color={tagFilter === "all" ? "primary" : "default"}
+                onClick={() => setFilterLogic("all")}
+                >
+                All
+              </Button>
+            </Tooltip>
+            <Tooltip title="Filter by Any">
+              <Button
+                size="small"
+                color={tagFilter === "any" ? "primary" : "default"}
+                onClick={() => setFilterLogic("any")}
+                >
+                Any
+              </Button>
+            </Tooltip>
+          </ButtonGroup>
+        </Box>
+        <Box m={2} className={clsx(classes.section, classes.tags)}>
+          <Box>
+            {allTags.sort().map((tag: string, index: number) => (
+              <Chip
+                color="primary"
+                variant="outlined"
+                avatar={
+                  tags.includes(tag) ? (
+                    <Zoom in={tags.includes(tag)}>
+                      <Avatar>
+                        <DoneIcon />
+                      </Avatar>
+                    </Zoom>
+                  ) : (
+                    undefined
+                  )
+                }
+                className={classes.tag}
+                key={index}
+                onClick={() => setTag(tag)}
+                label={tag}
+              />
+            ))}
+          </Box>
+        </Box>
+      </Paper>
+    </Hidden>
+  );
+};
+
+export default React.memo(Tags);

--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,7 @@ body {
 }
 
 code, pre {
+  font-size: 16px;
   font-family: 'Ubuntu Mono', source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -9,4 +9,6 @@ code, pre {
   font-size: 16px;
   font-family: 'Ubuntu Mono', source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
 }


### PR DESCRIPTION
Main purpose of this PR was to refine layouts of both index and details views. 

One major change is moving the _Tags_ section to the right side, as a sidebar. I thought moving it to the right saved the user a lot of scrolling time. Also, each column in the layout will now scroll independently, which should save the user some scrolling time.

I also refined the styles of the search bar. There are also a ton of responsiveness improvements.

<img width="1792" alt="Screen Shot 2020-06-04 at 3 12 45 PM" src="https://user-images.githubusercontent.com/485903/83804027-858cb200-a67b-11ea-9f90-56c04f1cd391.png">
<img width="1792" alt="Screen Shot 2020-06-05 at 10 41 50 AM" src="https://user-images.githubusercontent.com/485903/83889688-59c00980-a719-11ea-8619-53f81d29127b.png">
<img width="1792" alt="Screen Shot 2020-06-04 at 3 55 43 PM" src="https://user-images.githubusercontent.com/485903/83804355-00ee6380-a67c-11ea-962d-da20091b2376.png">
<img width="1792" alt="Screen Shot 2020-06-05 at 10 42 33 AM" src="https://user-images.githubusercontent.com/485903/83889770-604e8100-a719-11ea-9925-a0736f3e89ff.png">

