### PR TITLE
Use classes instead of className

### DIFF
--- a/src/classes.ts
+++ b/src/classes.ts
@@ -332,7 +332,7 @@ export const useQuestionDisplayStyles = makeStyles((theme: Theme) =>
       paddingLeft: theme.spacing(0.75),
       position: "absolute",
       left: 24,
-      [theme.breakpoints.down('md')]: {
+      "@media (max-width: 1470px)": {
         position: "static",
         marginBottom: theme.spacing(2),
       },

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -43,8 +43,10 @@ const Filters = () => {
         <Box m={2}>
           {allCategories.map((category: any) => (
             <FormControlLabel
-              className={classes.checkboxItem}
-              classes={{ label: classes.checkboxLabel}}
+              classes={{
+                root: classes.checkboxItem,
+                label: classes.checkboxLabel
+              }}
               onChange={() => setCategory(category)}
               key={category}
               control={
@@ -68,8 +70,10 @@ const Filters = () => {
           {[...Object.keys(managedQuestions.integrations), "none"].map(
             (integration: string, index: number) => (
               <FormControlLabel
-              className={classes.checkboxItem}
-              classes={{ label: classes.checkboxLabel}}
+              classes={{
+                root: classes.checkboxItem,
+                label: classes.checkboxLabel
+              }}
               key={index}
               control={
                 <Checkbox

--- a/src/components/QuestionsDisplay.tsx
+++ b/src/components/QuestionsDisplay.tsx
@@ -26,7 +26,9 @@ const QuestionsDisplay = (props: Props) => {
   return (
     <Card
       elevation={0}
-      className={clsx(classes.questionsCard, windowSize.width > 750 ? classes.root : classes.smallRoot)}
+      classes={{
+        root: clsx(classes.questionsCard, windowSize.width > 750 ? classes.root : classes.smallRoot)
+      }}
     >
       <Box className={clsx(classes.results, themeDark ? classes.resultsDark : undefined)}>
         {props.questions.length} of {managedQuestions.questions.length}


### PR DESCRIPTION
- Use classes instead of className to see if it resolves the missing styles I'm getting on dev with checkbox misalignment and questions section not scrolling.
- Add breakpoint for back button to wrap sooner

