### PR TITLE
Add empty state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ function App() {
       text: {
         primary: themeDark ? "#FFFFFF" : "#353945",
         secondary: themeDark ? "#d4d6e3" : "#596173",
-        hint: themeDark ? "#17305d" : "#8e97ab",
+        hint: themeDark ? "#3a4b7a" : "#8e97ab",
       }
     },
     typography: {
@@ -47,6 +47,7 @@ function App() {
       MuiCard: {
         root: {
           overflowY: "auto",
+          position: "relative",
         }
       },
       MuiCheckbox: {
@@ -64,8 +65,9 @@ function App() {
       },
       MuiFormControlLabel: {
         root: {
-          display: "flex",
           alignItems: "flex-start",
+          display: "flex",
+          marginRight: 0,
         }
       },
       MuiIconButton: {

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -5,7 +5,7 @@ import QuestionsDisplay from "./components/QuestionsDisplay";
 import Filters from "./components/Filters";
 import Tags from "./components/Tags";
 import filterQuestions, { FilterType } from "./methods/filterQuestions";
-import { Zoom } from "@material-ui/core";
+import { Fade } from "@material-ui/core";
 import { useWindowSize } from "@reach/window-size";
 import { Question } from "./types";
 import Context from "./AppContext";
@@ -50,7 +50,7 @@ const Main = () => {
 
   return (
     <>
-      <Zoom in={managedQuestions.questions.length >= 1}>
+      <Fade in={managedQuestions.questions.length >= 1}>
         <div
           style={{
             display: "flex",
@@ -61,7 +61,7 @@ const Main = () => {
           <QuestionsDisplay questions={filteredQuestions} />
           <Tags />
         </div>
-      </Zoom>
+      </Fade>
     </>
   );
 };

--- a/src/classes.ts
+++ b/src/classes.ts
@@ -98,7 +98,7 @@ export const useQuestionDisplayStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       flex: 3.5,
-      maxHeight: "calc(100vh - 99px)",
+      height: "calc(100vh - 99px)",
       padding: theme.spacing(1, 2, 2),
       margin: theme.spacing(0, 2),
       textDecoration: "none",
@@ -164,6 +164,26 @@ export const useQuestionDisplayStyles = makeStyles((theme: Theme) =>
     chevronRight: {
       color: theme.palette.primary.main,
       marginTop: theme.spacing(-0.5),
+    },
+    empty: {
+      alignItems: "center",
+      color: theme.palette.text.hint,
+      display: "flex",
+      flexFlow: "column",
+      height: "98%",
+      justifyContent: "center",
+      minHeight: 300,
+      textAlign: "center",
+      width: "100%",
+      [theme.breakpoints.down('sm')]: {
+        height: "auto"
+      },
+    },
+    emptyIcon: {
+      marginBottom: theme.spacing(1),
+      height: 60,
+      strokeWidth: 1.25,
+      width: 60,
     }
   })
   );
@@ -172,7 +192,7 @@ export const useQuestionDisplayStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       flex: 1,
-      maxHeight: "calc(100vh - 99px)",
+      height: "calc(100vh - 99px)",
       overflowY: "auto",
       padding: theme.spacing(1),
     },
@@ -204,6 +224,19 @@ export const useQuestionDisplayStyles = makeStyles((theme: Theme) =>
     icon: {
       color: "#8e97ab",
       margin: theme.spacing(0, 1, 0, 0.75),
+    },
+    checklist: {
+      [theme.breakpoints.down('sm')]: {
+        display: "grid",
+        gridTemplateColumns: "1fr 1fr 1fr",
+        gridGap: theme.spacing(0, 2),
+      },
+      "@media (max-width: 800px)": {
+        gridTemplateColumns: "1fr 1fr",
+      },
+      "@media (max-width: 600px)": {
+        gridTemplateColumns: "1fr",
+      },
     },
     checkboxLabel: {
       lineHeight: 1.25,

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -40,7 +40,7 @@ const Filters = () => {
           </Icon>
           <Typography variant="h6" className={classes.subtitle}>Category</Typography>
         </Box>
-        <Box m={2}>
+        <Box className={classes.checklist} m={2}>
           {allCategories.map((category: any) => (
             <FormControlLabel
               classes={{
@@ -65,7 +65,7 @@ const Filters = () => {
           </Icon>
           <Typography variant="h6" className={classes.subtitle}>Integrations</Typography>
         </Box>
-        <Box m={2}>
+        <Box className={classes.checklist} m={2}>
           {[...Object.keys(managedQuestions.integrations), "none"].map(
             (integration: string, index: number) => (
               <FormControlLabel

--- a/src/components/QuestionsDisplay.tsx
+++ b/src/components/QuestionsDisplay.tsx
@@ -1,9 +1,10 @@
 import React, { useContext } from "react";
 import clsx from "clsx";
-import { Typography, Card, Icon, Box, Divider } from "@material-ui/core";
+import { Typography, Card, Icon, Box, Divider, Fade } from "@material-ui/core";
 import { Question } from "../types";
 import { useQuestionDisplayStyles } from "../classes";
 import { useHistory } from "react-router-dom";
+import UnavailableIcon from "@lifeomic/react-brand-icons/jupiterone/unavailable";
 import ChevronRightIcon from "react-feather/dist/icons/chevron-right";
 import { useWindowSize } from "@reach/window-size";
 import Context from "../AppContext";
@@ -33,31 +34,44 @@ const QuestionsDisplay = (props: Props) => {
       <Box className={clsx(classes.results, themeDark ? classes.resultsDark : undefined)}>
         {props.questions.length} of {managedQuestions.questions.length}
       </Box>
-      {Object.keys(grouped).map((category, index) => (
+
+      {props.questions.length === 0 ? (
         <>
-          <p className={classes.headingBox}>
-            <Typography variant="h5" className={classes.heading}>
-              {category === "undefined" ? "No Category" : category}
-            </Typography>
-          </p>
-          <Divider className={classes.divider}/>
-          {grouped[category].map(question => (
-            <>
-              <div
-                className={classes.question}
-                key={index}
-                onClick={() => history.push(`/question/${question.hash}`)}
-              >
-                <span className={classes.item}>{question.title}</span>
-                <Icon className={classes.chevronRight}>
-                  <ChevronRightIcon />
-                </Icon>
-              </div>
-              <Divider className={classes.divider}/>
-            </>
-          ))}
+          <Fade in={props.questions.length <= 0}>
+            <Box className={classes.empty}>
+              <UnavailableIcon className={classes.emptyIcon} />
+              <Typography variant="h5">No questions based on search criteria</Typography>
+              <Typography variant="body1">Try removing a filter or tag</Typography>
+            </Box>
+          </Fade>
         </>
-      ))}
+      ) : (
+        Object.keys(grouped).map((category, index) => (
+          <>
+            <p className={classes.headingBox}>
+              <Typography variant="h5" className={classes.heading}>
+                {category === "undefined" ? "No Category" : category}
+              </Typography>
+            </p>
+            <Divider className={classes.divider}/>
+            {grouped[category].map(question => (
+              <>
+                <div
+                  className={classes.question}
+                  key={index}
+                  onClick={() => history.push(`/question/${question.hash}`)}
+                >
+                  <span className={classes.item}>{question.title}</span>
+                  <Icon className={classes.chevronRight}>
+                    <ChevronRightIcon />
+                  </Icon>
+                </div>
+                <Divider className={classes.divider}/>
+              </>
+            ))}
+          </>
+        ))
+      )}
     </Card>
   );
 };


### PR DESCRIPTION
- Add empty state
- Improve responsiveness of checklists. Use three- and two- column layout for checklists on smaller screens.
- Replace zoom with fade
- Remove max height in favor of height for scroll columns

<img width="1586" alt="Screen Shot 2020-06-08 at 5 15 16 PM" src="https://user-images.githubusercontent.com/485903/84081282-a9b5ff00-a9ab-11ea-8c1c-deea3c78667b.png">
<img width="1060" alt="Screen Shot 2020-06-08 at 5 15 10 PM" src="https://user-images.githubusercontent.com/485903/84081275-a753a500-a9ab-11ea-8d60-3b02d4b0d3c9.png">
<img width="723" alt="Screen Shot 2020-06-08 at 5 12 46 PM" src="https://user-images.githubusercontent.com/485903/84081117-5f348280-a9ab-11ea-995e-9a241a171975.png">
