### PR TITLE
Sort Category and Integration filter checkboxes alphabetically

### DIFF
--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -40,7 +40,7 @@ const Filters = () => {
           <Typography variant="h6" className={classes.subtitle}>Category</Typography>
         </Box>
         <Box className={classes.checklist} m={2}>
-          {allCategories.map((category: any) => (
+          {[...allCategories].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' })).map((category: any) => (
             <FormControlLabel
               classes={{
                 label: classes.checkboxLabel
@@ -65,7 +65,11 @@ const Filters = () => {
           <Typography variant="h6" className={classes.subtitle}>Integrations</Typography>
         </Box>
         <Box className={classes.checklist} m={2}>
-          {[...Object.keys(managedQuestions.integrations), "none"].map(
+          {[...Object.keys(managedQuestions.integrations)].sort((a, b) =>
+            (managedQuestions.integrations[a]?.title ?? '').localeCompare(
+              managedQuestions.integrations[b]?.title ?? '', undefined, { sensitivity: 'base' }
+            )
+          ).concat("none").map(
             (integration: string, index: number) => (
               <FormControlLabel
               classes={{


### PR DESCRIPTION
## Summary
- Sort Category checkbox filters alphabetically (case-insensitive) so users can find items more easily
- Sort Integration checkbox filters alphabetically by display title (case-insensitive), keeping "None" pinned at the bottom
- Previously both lists were in arbitrary insertion order, which made scanning for a specific category or integration unnecessarily difficult

## Test plan
- [x] Open the Questions Library page
- [x] Verify Category checkboxes are listed A-Z
- [x] Verify Integration checkboxes are listed A-Z with "None" at the bottom
- [x] Confirm selecting/deselecting filters still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)